### PR TITLE
Fix coinslot centering

### DIFF
--- a/Box_Template.scad
+++ b/Box_Template.scad
@@ -79,6 +79,7 @@ show_lid=true;	// Whether or not to render the lid. To make open boxes with no l
 //has_snap=true; // Add small ridges or snaps to lids to help keep them closed.
 //coinslot_x=20;	// Size in X direction
 //coinslot_y=2.5;	// Size in Y direction
+//coinslot_corner_radius=0; // rounded coinslot corners if >0; best if less than half the shorter coinslot dimension
 //z_tolerance=0;   // Z tolerance can be tweaked separately, to make the top of the sliding lid be flush with the top of the box itself.
 //extra_bottom=.15; // Extra bottm wall height to fit type 4 slider.
 //hinge_inset=.75; // Size of the hinge connection.

--- a/Ultimate_Box_Generator.scad
+++ b/Ultimate_Box_Generator.scad
@@ -70,6 +70,7 @@ has_coinslot=false; // Add slot in the top for dropping in components.
 has_snap=true; // Add small ridges or snaps to lids to help keep them closed.
 coinslot_x=20;	// Size in X direction
 coinslot_y=2.5;	// Size in Y direction
+coinslot_corner_radius=0; // rounded coinslot corners if >0; best if less than half the shorter coinslot dimension
 z_tolerance=0;   // Z tolerance can be tweaked separately, to make the top of the sliding lid be flush with the top of the box itself.
 extra_bottom=.15; // Extra bottm wall height to fit type 4 slider.
 hinge_inset=.75; // Size of the hinge connection.
@@ -950,7 +951,21 @@ module make_lid() {
                                 xslot * ( comp_size_x + wall ) + (2-(lid_type==5 ? 0 : 1))*wall + (comp_size_x-coinslot_x)/2, 
                                 yslot * ( comp_size_y + wall ) + wall*(2-3*(lid_type==5?0:1)/2) + (comp_size_y-coinslot_y)/2, 
                                 - oversize])
-                            cube ( size = [ coinslot_x, coinslot_y, wall + oversize*2]);
+                                intersection() {
+                                    cube ( size = [ coinslot_x, coinslot_y, wall + oversize*2]);
+                                    if (coinslot_corner_radius > 0) {
+                                        hull() {
+                                           translate([coinslot_corner_radius, coinslot_corner_radius, 0])
+                                               cylinder(h=wall+oversize*2, r=coinslot_corner_radius);
+                                           translate([coinslot_x - coinslot_corner_radius, coinslot_y - coinslot_corner_radius, 0])
+                                               cylinder(h=wall+oversize*2, r=coinslot_corner_radius);
+                                           translate([coinslot_x - coinslot_corner_radius, coinslot_corner_radius, 0])
+                                               cylinder(h=wall+oversize*2, r=coinslot_corner_radius);
+                                           translate([coinslot_corner_radius, coinslot_y - coinslot_corner_radius, 0])
+                                               cylinder(h=wall+oversize*2, r=coinslot_corner_radius);
+                                        }
+                                    }
+                                }
                         }
                     }
                 }

--- a/Ultimate_Box_Generator.scad
+++ b/Ultimate_Box_Generator.scad
@@ -156,7 +156,23 @@ function make_object(x, y, z, offset_x, offset_y, repeat_x, repeat_y, color) = [
     [color]
 ];
 
-/*** More complex module that itterates through complex_box to create many boxes. ***/
+function calc_coinslot_wall_offset_multiplier_x() = (
+                                    lid_type == 1 ? 1.0
+                                   :lid_type == 2 ? 1.0
+                                   :lid_type == 3 ? 1.0
+                                   :lid_type == 4 ? 1.0
+                                   :lid_type == 5 ? 2.0
+                                   : 1.0);
+
+function calc_coinslot_wall_offset_multiplier_y() = (
+                                    lid_type == 1 ? 0.5
+                                   :lid_type == 2 ? 0.5
+                                   :lid_type == 3 ? 1.0
+                                   :lid_type == 4 ? 0.5
+                                   :lid_type == 5 ? 2.0
+                                   : 1.0);
+
+/*** More complex module that iterates through complex_box to create many boxes. ***/
 module make_complex_box() {
     intersection() {     
         translate([wall, wall, wall])
@@ -942,14 +958,15 @@ module make_lid() {
                         }
                 }
             
+                // This is the coinslot opening to be removed
                 if (has_coinslot==true) {
                     for ( yslot = [ 0 : repeat_y - 1])
                     {
                         for( xslot = [ 0 : repeat_x - 1])
                         {
                             translate([ 
-                                xslot * ( comp_size_x + wall ) + (2-(lid_type==5 ? 0 : 1))*wall + (comp_size_x-coinslot_x)/2, 
-                                yslot * ( comp_size_y + wall ) + wall*(2-3*(lid_type==5?0:1)/2) + (comp_size_y-coinslot_y)/2, 
+                                xslot * ( comp_size_x + wall ) + (calc_coinslot_wall_offset_multiplier_x())*wall + (comp_size_x-coinslot_x)/2, 
+                                yslot * ( comp_size_y + wall ) + (calc_coinslot_wall_offset_multiplier_y())*wall + (comp_size_y-coinslot_y)/2, 
                                 - oversize])
                                 intersection() {
                                     cube ( size = [ coinslot_x, coinslot_y, wall + oversize*2]);
@@ -1043,11 +1060,11 @@ module make_lid_mesh(x, y, internal_wall=internal_wall, wall=wall, box_x, box_y,
                     translate([offset_x , offset_y, - oversize])
                     make_mesh(comp_size_x, comp_size_y, mesh_alt_rotation, mesh_type=mesh_type, inverted=true);
                             
+                    // This is the solid box around the coinslot opening
                     if (has_coinslot==true) {        
-                        translate([ 
+                        translate([
                             xbox * ( comp_size_x + wall ) + (comp_size_x-coinslot_x)/2 -mesh_inset_padding -2.5, 
-                            ybox * ( comp_size_y + wall ) + wall*(2-3/2) + (comp_size_y-coinslot_y)/2 -mesh_inset_padding -4, 
-                            - oversize])
+                            ybox * ( comp_size_y + wall ) + (comp_size_y-coinslot_y)/2 -mesh_inset_padding -2.5])
                         // The 2.5 above is hardcoded because of the 5 hardcoded here.
                         cube ( size = [ coinslot_x +5, coinslot_y +5, wall + oversize*2 ]);
                     }

--- a/Ultimate_Box_Generator.scad
+++ b/Ultimate_Box_Generator.scad
@@ -1064,7 +1064,8 @@ module make_lid_mesh(x, y, internal_wall=internal_wall, wall=wall, box_x, box_y,
                     if (has_coinslot==true) {        
                         translate([
                             xbox * ( comp_size_x + wall ) + (comp_size_x-coinslot_x)/2 -mesh_inset_padding -2.5, 
-                            ybox * ( comp_size_y + wall ) + (comp_size_y-coinslot_y)/2 -mesh_inset_padding -2.5])
+                            ybox * ( comp_size_y + wall ) + (comp_size_y-coinslot_y)/2 -mesh_inset_padding -2.5,
+                            - oversize])
                         // The 2.5 above is hardcoded because of the 5 hardcoded here.
                         cube ( size = [ coinslot_x +5, coinslot_y +5, wall + oversize*2 ]);
                     }


### PR DESCRIPTION
Another attempt at fixing the offsets for coinslots. This time, it looks correct for all lid types 1 through 5, but I only looked at single compartment boxes. I didn't dive into the details of how the calculations were being done for the various lid types. Instead, I just experimentally adjusted each one.

This PR also includes the change for my previous PR that implements optional rounded corners for coinslot openings.