### PR TITLE
Fix typos, Markdown syntax, and indentations

### DIFF
--- a/Box_Template.scad
+++ b/Box_Template.scad
@@ -10,7 +10,7 @@ include    <Ultimate_Box_Generator.scad>;
 // At this point you can start to adjust builtin varaibles and create your own. There are also some examples of more complex boxes at the end of the file.
 
 
-// Parts to render. To do more complex opperations disable these and manually call make_box() and make_lid() instead.
+// Parts to render. To do more complex operations disable these and manually call make_box() and make_lid() instead.
 show_box=true;	// Whether or not to render the box
 show_lid=true;	// Whether or not to render the lid. To make open boxes with no lid set `show_lid=false` and `lid_type=5`.
 
@@ -24,31 +24,32 @@ show_lid=true;	// Whether or not to render the lid. To make open boxes with no l
 //tolerance=.15;      // Tolerance around lid.  If it's too tight, increase this. If it's too loose, decrease it.
 
 // Box Rounding
-//box_corner_radius=0; // Add a rounding affect to the corners of the box. Anything over `wall` will cause structure and lid problems.
-//internal_corner_radius=0; // Add a rounding affect to the inside.
-//mesh_corner_radius=0; // Leave a radius around each corner of the mesh. May hep with bridges.
+//box_corner_radius=0; // Add a rounding effect to the corners of the box. Anything over `wall` will cause structure and lid problems.
+//box_corner_radius_axis=[true, true, true]; // Apply rounding on [X, Y, Z] Axis
+//internal_corner_radius=0; // Add a rounding effect to the inside.
+//mesh_corner_radius=0; // Leave a radius around each corner of the mesh. May help with bridges.
 //corner_fn=30;
 
-// Supress individual walls.
+// Suppress individual walls.
 //supress_walls_x=[]; // These are the walls running along the X axis. It should be an array of size [repeat_y-1][repeat_x].
 //supress_walls_y=[]; // These are the walls running along the Y axis. It should be an array of size [repeat_x-1][repeat_y].
 // Example for repeat_x=4, repeat_y=3:
 //supress_walls_x=[[1,0,1,1],[0,1,0,1]];
 //supress_walls_y=[[1,0,1],[0,1,1],[1,1,1]];
-//supress_sides=false; // [X, Y, X, Y] Cutout/supress some sides. this may behave baddly with compartments or mesh.
+//supress_sides=false; // [X, Y, X, Y] Cutout/supress some sides. this may behave badly with compartments or mesh.
 //supress_sides_radius=wall; // Add a rounding to the cutout.
-//supress_sides_offset=0; // 0, wall, [X, Y, Z] adjsut the coutout in all directions. + to grow, - so shrink
+//supress_sides_offset=0; // 0, wall, [X, Y, Z] adjust the coutout in all directions. + to grow, - to shrink
 //supress_sides_fn=30;
 
 // Mesh Settings
 // To make rounded corners and no mesh use any `mesh_type` > 0 and set `strut_gap` to a high value.
 // 0: No mesh, solid wall.
 // 1: Single direction mesh.
-// 2: Two direction cross mesh and 90 degree angle to eachother.
-// 3: Two direction mesh but mirrored around 90 axsis instead or rotated 90 degrees.
+// 2: Two direction cross mesh at 90 degree angle to eachother.
+// 3: Two direction mesh but mirrored around 90 axis instead or rotated 90 degrees.
 // 4: Calculate angle across the diagonal of each opening. You will also want to change `strut_gap` to a large number and set `strut_count_min=1`.
 // 5: No mesh, empty wall.
-// 6: Honycomb. Also set `strut_width=wall/4` and `strut_gap=wall*2`. To big of a `strut_gap` may fail to print. Other shapes can be generated with `mesh_fn` and reducing `mesh_inset_padding` may help.
+// 6: Honycomb. Also set `strut_width=wall/4` and `strut_gap=wall*2`. Too big of a `strut_gap` may fail to print. Other shapes can be generated with `mesh_fn` and reducing `mesh_inset_padding` may help.
 //mesh_type=0; // Mesh type, see above.
 //mesh_rotation=0; // 0-90 degrees.
 //mesh_alt_rotation=mesh_rotation; // Alternate rotation for top and bottom faces.
@@ -57,23 +58,23 @@ show_lid=true;	// Whether or not to render the lid. To make open boxes with no l
 //mesh_do_top=true; // Include mesh on top piece.
 //mesh_do_interior=false; // Include mesh on inner walls.
 //mesh_inset_padding=wall; // Leave some solid material before building strut frame. Anything less then wall/2 will likely fall apart.
-//mesh_fn=mesh_type == 6 ? 6 : 40; // Complexity of curves in mesh's, increese for smoother curves.
+//mesh_fn=mesh_type == 6 ? 6 : 40; // Complexity of curves in meshes, increase for smoother curves.
 //strut_width=wall*2; // Width of each strut, 0=hollow.
 //strut_gap=wall; // Width of the air gap between each strut. 0=fine air gaps.
 //strut_count_min=0; // Optinal minimum number of struts regardless of size calulations.
-//alt_strut_width=strut_width; // Width of struts going the other directions.
+//alt_strut_width=strut_width; // Width of struts going the other direction.
 //alt_strut_gap=strut_gap; // Width of gap going the other direction.
-//alt_strut_count_min=strut_count_min; // Optinal minimum number of struts regardless of size calulations.
+//alt_strut_count_min=strut_count_min; // Optional minimum number of struts regardless of size calculations.
 //mesh_overflow=0; // Extra rows to add to the mesh. For example in the Honeycomb partial hexegons will be created along the edges.
 
 // Lid Settings
 // 0: No Lid. top may be rounded and can cause other rendering changes.
 // 1: Lid that slides off in the x direction.
-// 2: Lid with a snapped in hinge that rotates open
+// 2: Lid with a snapped in hinge that rotates open, will make box one wall taller.
 // 3: Lid that snaps down onto the box. Also need to change lid_height to around 1.5mm.
-// 4: Stackable version of cover 1 there boxes slide into one another. You will need one cover for the last box. (Not tested)
-// 5: Oversized lid sits on top and has sides that extend down. (Needs snapp support)
-// 6: Stacking boxes, will make box 1/2 wall taller.
+// 4: Stackable version of cover 1. The boxes slide into one another. You will need one cover for the last box.
+// 5: Oversized lid sits on top and has sides that extend down. (Needs snap support)
+// 6: Stacking boxes, will make box 1/2 walls taller.
 //lid_type=1; // Lid type, see above.
 //has_thumbhole=true; // Add gripping locations for easy opening.
 //has_coinslot=false; // Add slot in the top for dropping in components.
@@ -82,7 +83,7 @@ show_lid=true;	// Whether or not to render the lid. To make open boxes with no l
 //coinslot_y=2.5;	// Size in Y direction
 //coinslot_corner_radius=0; // rounded coinslot corners if >0; best if less than half the shorter coinslot dimension
 //z_tolerance=0;   // Z tolerance can be tweaked separately, to make the top of the sliding lid be flush with the top of the box itself.
-//extra_bottom=.15; // Extra bottm wall height to fit type 4 slider.
+//extra_bottom=.15; // Extra bottom wall height to fit type 4 slider.
 //hinge_inset=.75; // Size of the hinge connection.
 //snap_inset=.25; // Amount of overhang for snaps to snap into place.
 //snap_tolerance=tolerance; // You may need to add tolerance around lid and snaps to let them move freely.
@@ -94,39 +95,39 @@ show_lid=true;	// Whether or not to render the lid. To make open boxes with no l
 //Internal Structure (You may need to turn off `mesh_do_sides` or `mesh_do_bottom` for good results.)
 // You can also use `make_wall()` to manually add your own walls.
 // 1: Rounded bottom frame.
-// 2: Hexegon bottom frame. (To make this shape perfect set `comp_size_deep` to the width between to edges of the tile and set `comp_size_x` or `comp_size_y` to this this: `comp_size_deep / sqrt(3)*2`.
+// 2: Hexegon bottom frame. (To make this shape perfect set `comp_size_deep` to the width between to edges of the tile and set `comp_size_x` or `comp_size_y` to this: `comp_size_deep / sqrt(3)*2`.
 // 3: Rough bottom for make bits sit unevenly. (Partial)
-// 4: Verical rounding on cordner. Set `internal_size_deep` to `comp_size_deep` and `internal_size_circle` to the shortest `comp_size` for a circle.
-// 5: Vertical hexegon. Retulst may varry.
+// 4: Verical rounding on corner. Set `internal_size_deep` to `comp_size_deep` and `internal_size_circle` to the shortest `comp_size` for a circle.
+// 5: Vertical hexagon. Results may varry.
 //internal_type=0; // Internal structure, see above.
 //internal_rotate=false; // On lid axis or rotate to opposite.
 //internal_size_deep=comp_size_deep/2; // How far into the box to start the internal structure. Should be `comp_size_deep/2` for type 1-2, `wall` for 3, or comp_size_deep for type 4-5.
 //internal_size_circle=internal_type==1 ? internal_size_deep : internal_size_deep * 2 / sqrt(3); // Use this calculation, or the shorter comp_size for type 4-5.
 //internal_fn=internal_type==1 || internal_type==4 ? 60 : 6; // Complexity of internal curves, may need to increase for larger or smoother curves.
 //internal_wall=wall; // Custom size for internal walls.
-//internal_wall_deep=comp_size_deep; // If set to lower then comp_size_deep then the internal walls will be this tall.
+//internal_wall_deep=comp_size_deep; // If set to lower than comp_size_deep then the internal walls will be this tall.
 
 // Text Settings
 // 0: None.
-// 1: Cutout. Remove material formt he wall.
-// 2: Raised. If a mesh is ued part of it is filled in to hold the text. Lids 0 and 3 are printed upside down by default. With this option used they will require supports regardless of the orrientation printed.
+// 1: Cutout. Remove material from the wall.
+// 2: Raised. If a mesh is used, part of it is filled in to hold the text. Lids 0 and 3 are printed upside down by default. With this option used they will require supports regardless of the orrientation printed.
 //text_type=0; // Text type, see above.
-//text_depth=wall/6; // Distance to cutout text or raise it. User `wall` to cut through.
+//text_depth=wall/6; // Distance to cutout text or raise it. Use `wall` to cut through.
 //text_size=5; // Font Size.
-//text_font="Courier New:style=Bold"; // Use Hepl -> Font List to see options.
+//text_font="Courier New:style=Bold"; // Use Help -> Font List to see options.
 //text_message="Red Player"; // Message Text, or use `["Line 1", "Line 2"]` for multiline.
-//text_message_compartments=false;//[["AA", "BB", "CC"], ["AB", "BC", "CD"]]; // Custom text for compartments in top or bottom. Also support multiline as `[[ ["A", "B"] ]]`.
+//text_message_compartments=false;//[["AA", "BB", "CC"], ["AB", "BC", "CD"]]; // Custom text for compartments in top or bottom. Also supports multiline as `[[ ["A", "B"] ]]`.
 //text_sides=true;//[true, true, true, false]; // Sides to put text on, [X, Y, X, Y]
 //text_top=true; // Put Text on the top.
 //text_bottom=false; // Put Text on the bottom.
 //text_rotation=0; // Rotate the top and bottom text by X degrees. 90 will rotate from the X axis to the Y axis.
 //text_offset=0; // Text is verticaly centered in the wall. This may look "off" due to casing or hanging tails. You can manually adjust the vertical alignment with this setting.
 //text_fn=30; // Complexity of the letters, may need to increese with larger fonts.
-//text_backdrop_scale=[.9, 1.5]; // Font size scaleing used on the backdrop when `text_type=2` is used on sides with a mesh.
+//text_backdrop_scale=[.9, 1.5]; // Font size scaling used on the backdrop when `text_type=2` is used on sides with a mesh.
 
 // Complex Structure
 //make_complex_box=false; // Use an array of objects from `complex_box` to create many smaller boxes within the larger box.
-//internal_grow_down=true; // If set compartments will be extruded into the larger box from the top to make a flush surface. (May make a model that uses a lot of material.
+//internal_grow_down=true; // If set compartments will be extruded into the larger box from the top to make a flush surface. (May result in a model that uses a lot of material).
 //internal_empty_bottom=false; // If set the area blow each box will be empty. This will not be printable on a FDM printer unless supports are included internally but still may save material and print time.
 
 
@@ -177,6 +178,6 @@ complex_box=[
 make_complex_box=true;*/
 
 // Some notes on complex prints:
-/* OpenSCAD expereicne is required to do pretty much any type of customization or complex opperations. This will essentaily jsut make the containers within one larger object with a single lid. Alternatly multiple boxes could be reated and then joined together with translations to make a larger object with multiple lids. 
-   Due to how variables are passed in OpenSCAD it can be tricky to get the parameters set on the parent box and child boxes as you want. It is best to use global variable assignmets to set the child box parameters, then pass overrides to the `make_box()` call yourself. (You have to also set `show_box=false;` if you ddo this.)
-  */
+/* OpenSCAD experience is required to do pretty much any type of customization or complex operations. This will essentaily just make the containers within one larger object with a single lid. Alternatly multiple boxes could be created and then joined together with translations to make a larger object with multiple lids. 
+   Due to how variables are passed in OpenSCAD it can be tricky to get the parameters set on the parent box and child boxes as you want. It is best to use global variable assignmets to set the child box parameters, then pass overrides to the `make_box()` call yourself. (You have to also set `show_box=false;` if you do this.)
+*/

--- a/README.md
+++ b/README.md
@@ -1,20 +1,21 @@
 # Ultimate-Box-Generator
-https://www.thingiverse.com/thing:2594893/files
+
+<https://www.thingiverse.com/thing:2594893/files>
 
 This is the repo for the Ultimate Box Generator on Thingiverse
 
 ## Getting Started
 
-This is a OpenSCAD script for generating configurable boxes. You will need to download OpenSCAD and install it. Then you will be able to open these files and create custom models. In OpenSCAD you can preview the files as you make changes. To generate a STL file need to Render the model first then click the Export as STL to save the printable model. 
+This is a OpenSCAD script for generating configurable boxes. You will need to download OpenSCAD and install it. Then you will be able to open these files and create custom models. In OpenSCAD you can preview the files as you make changes. To generate a STL file need to Render the model first then click the Export as STL to save the printable model.
 
 Note that it is possible to generate items that won't actualy be printable with this tool.
 
-See the thingiverse link above for more details or review the comments in the script file. 
+See the thingiverse link above for more details or review the comments in the script file.
 
-https://openscad.org
+<https://openscad.org>
 
 ## License
 
-https://creativecommons.org/licenses/by/4.0/
+<https://creativecommons.org/licenses/by/4.0/>
 
-Contributors: Jeremy Pyne (https://github.com/pynej), https://github.com/wjcarpenter
+Contributors: Jeremy Pyne (<https://github.com/pynej>), <https://github.com/wjcarpenter>

--- a/Ultimate_Box_Generator.scad
+++ b/Ultimate_Box_Generator.scad
@@ -167,9 +167,9 @@ module make_complex_box() {
         translate([wall-internal_wall, wall-internal_wall, wall-internal_wall])
         //for(row = complex_box) {
             for(area = complex_box) {
-               translate(area[1])
-               color(area[5][0])
-               make_internal_box(area[0][0], area[0][1], area[0][2], wall=internal_wall, repeat_x=area[2][0], repeat_y=area[2][1]);
+                translate(area[1])
+                color(area[5][0])
+                make_internal_box(area[0][0], area[0][1], area[0][2], wall=internal_wall, repeat_x=area[2][0], repeat_y=area[2][1]);
             }
         //}
     }
@@ -184,7 +184,7 @@ module make_wall(row, offset, rotate, internal_size_deep=internal_size_deep, int
         cube([rotate ? comp_size_x : internal_wall, rotate ? internal_wall : comp_size_y, internal_size_deep]);
         rotate([rotate ? 90 : 0, rotate ? 0 : -90, 0])
         translate([mesh_inset_padding, mesh_inset_padding, - .5-internal_wall])
-	  make_mesh(rotate ? comp_size_x : internal_size_deep - wall*(lid_type==5?1:0), rotate ? internal_size_deep - wall*(lid_type==5?1:0) : comp_size_y, mesh_rotation, mesh_type=mesh_type, !rotate);
+	    make_mesh(rotate ? comp_size_x : internal_size_deep - wall*(lid_type==5?1:0), rotate ? internal_size_deep - wall*(lid_type==5?1:0) : comp_size_y, mesh_rotation, mesh_type=mesh_type, !rotate);
     }
 }
 
@@ -214,7 +214,7 @@ module make_struts (x, y, thickness, number_of_struts, struts_width, angle, mesh
                     // Correct for rotated Y sides
                     translate([0,angle >= 90 ? y - strut_gap : 0, 0])
                     rotate([0, 0, angle >= 90 ? -90 : 0])
-             
+
                     for (i = [0 :  floor(no_x)]) {
                         translate([i * pos_x, (i % 2) * pos_y, 0])
                         for (r = [0 :  floor(no_y_extra <= .5 && i % 2 ? no_y - 1 : no_y )  ]) {
@@ -228,7 +228,7 @@ module make_struts (x, y, thickness, number_of_struts, struts_width, angle, mesh
                 // Line Mesh
                 intersection(){
                     square([x,y]);
-              
+
                     if (angle2 <= 90 && angle >=0) {
                         cosa = x/hypotenuse;
                         for ( i = [1 : number_of_struts] ) {
@@ -511,7 +511,7 @@ module make_box() {
                 #cube([box_x, box_y, wall]);
             
                 translate([0,wall/2+tolerance,0])
-               union() {
+                union() {
                     //Slide
                     rotate([90,0,90])
                     linear_extrude(box_x - wall/2)
@@ -540,10 +540,10 @@ module make_box() {
         
         if(lid_type==6) {
             difference() {
-               cube([box_x, box_y, wall/2]);
-               translate([wall/2+tolerance, wall/2+tolerance, 0])
-               union() {
-                   intersection() {
+                cube([box_x, box_y, wall/2]);
+                translate([wall/2+tolerance, wall/2+tolerance, 0])
+                union() {
+                    intersection() {
                         rotate([90,0,90])
                         linear_extrude(box_x - wall - tolerance*2)
                         polygon([
@@ -552,7 +552,7 @@ module make_box() {
                             [box_y-tolerance*2-wall,wall/2],
                             [tolerance*2,wall/2],
                         ]);
-                   
+
                         rotate([-90,0,0])
                         translate([0, -wall/2, 0])
                         linear_extrude(box_y - wall)
@@ -562,14 +562,14 @@ module make_box() {
                             [box_x-tolerance*2-wall*1.5,wall],
                             [wall/2+tolerance*2,wall],
                         ]);
-                   }
+                    }
                 }
             }
             
             difference() {
                 translate([wall/2, wall/2, box_z - wall/2])
                 union() {
-                   intersection() {
+                    intersection() {
                         rotate([90,0,90])
                         linear_extrude(box_x - wall)
                         polygon([
@@ -578,7 +578,7 @@ module make_box() {
                             [box_y-wall,wall/2],
                             [0,wall/2],
                         ]);
-                   
+
                         rotate([-90,0,0])
                         translate([0, -wall/2, 0])
                         linear_extrude(box_y - wall)
@@ -665,7 +665,7 @@ module make_text(box_x, box_y, box_z, base_rotation, rotate_z) {
                                     square([text_size*len(text_message[i])*text_backdrop_scale[0] - text_size, text_size*text_backdrop_scale[1] - text_size]);
                                     circle(text_size/2, $fn=20);
                                 }
-                          }
+                        }
                     } else {
                         translate([-text_size*len(text_message)*text_backdrop_scale[0]/2 +text_size/2, -text_size*text_backdrop_scale[1]/2 + text_size/2])
                         minkowski() {
@@ -686,7 +686,7 @@ module make_text(box_x, box_y, box_z, base_rotation, rotate_z) {
                     union(){
                         for (i = [0 : len(text_message) - 1])
                           translate([0 , -i * (text_size + 2) , 0 ]) text(text_message[i], font = text_font, size = text_size, valign = "center", halign = "center", $fn=text_fn);
-                      }
+                    }
                 } else {
                     text(text = str(text_message), font = text_font, size = text_size, valign = "center", halign = "center", $fn=text_fn);
                 }
@@ -704,7 +704,7 @@ module make_internal_box(comp_size_x, comp_size_y, comp_size_z) {
     union() {
         translate([0, 0, internal_grow_down && comp_size_z < comp_size_deep ? comp_size_deep - comp_size_z : 0])
         make_box(comp_size_x=comp_size_x, comp_size_y=comp_size_y, comp_size_deep=comp_size_z, mesh_do_sides=mesh_do_interior, wall=internal_wall, internal_wall=internal_wall, repeat_x=repeat_x, repeat_y=repeat_y, mesh_type=mesh_type, internal_type=internal_type, internal_size_deep=internal_size_deep, internal_fn=internal_fn, internal_rotate=internal_rotate);
-         
+
         if(internal_grow_down && comp_size_deep - comp_size_z > 0 && !internal_empty_bottom) {
             cube([box_x, box_y, comp_size_deep - comp_size_z]);
         }
@@ -740,8 +740,8 @@ module make_box_internal(comp_size_x=comp_size_x, comp_size_y=comp_size_y, inter
                                 rotate([0,0,90])
                             if(!internal_rotate && supress_walls_x[ybox][xbox] || internal_rotate && supress_walls_y[xbox][ybox])
                                 square([internal_size_circle*2, internal_size_circle*2], center=true);
-                             else
-                                 circle(r=internal_size_circle, $fn=internal_fn);
+                            else
+                                circle(r=internal_size_circle, $fn=internal_fn);
                         }
                     }
                 }
@@ -891,7 +891,7 @@ module make_lid() {
                                         cube (size=[20,box_y,wall+.1], center=false);
                                     }
                                 }
-                     
+
                                 if(lid_type==2) {
                                     rotate([0, 90, 0])
                                     translate([-wall, wall*2, -.01])
@@ -985,12 +985,12 @@ module make_lid() {
                         }
                         lip = min(mesh_inset_padding, wall*2/3);
                         
-                       
+
                         translate([ 0, 0, wall])
                         difference() {
                             translate([wall/2+tolerance, wall/2+tolerance, 0])
                             union() {
-                               intersection() {
+                                intersection() {
                                     rotate([90,0,90])
                                     linear_extrude(box_x - wall  - tolerance*2)
                                     polygon([
@@ -999,7 +999,7 @@ module make_lid() {
                                         [box_y-tolerance*2-wall,0],
                                         [tolerance*2,0],
                                     ]);
-                               
+
                                     rotate([-90,0,0])
                                     translate([0, -wall/2, 0])
                                     linear_extrude(box_y - wall)
@@ -1024,7 +1024,7 @@ module make_lid() {
                         translate([lid_type == 5 ? -wall - tolerance : 0, lid_type == 5  ? wall + tolerance : 0, lid_type == 4 ? extra_bottom : 0])
                         translate([box_x/2, box_y/2 - wall/2, wall - text_depth])
                         make_text(box_x, box_z, box_y, -90, true);
-                     else
+                    else
                         for ( ybox = [ 0 : repeat_y - 1])
                         {
                             for( xbox = [ 0 : repeat_x - 1])
@@ -1058,14 +1058,14 @@ module make_lid() {
                                     cube ( size = [ coinslot_x, coinslot_y, wall + oversize*2]);
                                     if (coinslot_corner_radius > 0) {
                                         hull() {
-                                           translate([coinslot_corner_radius, coinslot_corner_radius, 0])
-                                               cylinder(h=wall+oversize*2, r=coinslot_corner_radius, $fn=40);
-                                           translate([coinslot_x - coinslot_corner_radius, coinslot_y - coinslot_corner_radius, 0])
-                                               cylinder(h=wall+oversize*2, r=coinslot_corner_radius, $fn=40);
-                                           translate([coinslot_x - coinslot_corner_radius, coinslot_corner_radius, 0])
-                                               cylinder(h=wall+oversize*2, r=coinslot_corner_radius, $fn=40);
-                                           translate([coinslot_corner_radius, coinslot_y - coinslot_corner_radius, 0])
-                                               cylinder(h=wall+oversize*2, r=coinslot_corner_radius, $fn=40);
+                                            translate([coinslot_corner_radius, coinslot_corner_radius, 0])
+                                                cylinder(h=wall+oversize*2, r=coinslot_corner_radius, $fn=40);
+                                            translate([coinslot_x - coinslot_corner_radius, coinslot_y - coinslot_corner_radius, 0])
+                                                cylinder(h=wall+oversize*2, r=coinslot_corner_radius, $fn=40);
+                                            translate([coinslot_x - coinslot_corner_radius, coinslot_corner_radius, 0])
+                                                cylinder(h=wall+oversize*2, r=coinslot_corner_radius, $fn=40);
+                                            translate([coinslot_corner_radius, coinslot_y - coinslot_corner_radius, 0])
+                                                cylinder(h=wall+oversize*2, r=coinslot_corner_radius, $fn=40);
                                         }
                                     }
                                 }

--- a/Ultimate_Box_Generator.scad
+++ b/Ultimate_Box_Generator.scad
@@ -14,32 +14,32 @@ repeat_y = 1;		// Number of compartments, Y
 tolerance=.15;      // Tolerance around lid.  If it's too tight, increase this. If it's too loose, decrease it.
 
 // Box Rounding
-box_corner_radius=0; // Add a rounding affect to the corners of the box. Anything over `wall` will cause structure and lid problems.
+box_corner_radius=0; // Add a rounding effect to the corners of the box. Anything over `wall` will cause structure and lid problems.
 box_corner_radius_axis=[true, true, true]; // Apply rounding on [X, Y, Z] Axis
-internal_corner_radius=0; // Add a rounding affect to the inside.
-mesh_corner_radius=0; // Leave a radius around each corner of the mesh. May hep with bridges.
+internal_corner_radius=0; // Add a rounding effect to the inside.
+mesh_corner_radius=0; // Leave a radius around each corner of the mesh. May help with bridges.
 corner_fn=30;
 
-// Supress individual walls/sides.
+// Suppress individual walls/sides.
 supress_walls_x=[]; // These are the walls running along the X axis. It should be an array of size [repeat_y-1][repeat_x].
 supress_walls_y=[]; // These are the walls running along the Y axis. It should be an array of size [repeat_x-1][repeat_y].
 // Example for repeat_x=4, repeat_y=3:
 //supress_walls_x=[[1,0,1,1],[0,1,0,1]];
 //supress_walls_y=[[1,0,1],[0,1,1],[1,1,1]];
-supress_sides=false; // [X, Y, X, Y] Cutout/supress some sides. this may behave baddly with compartments or mesh.
+supress_sides=false; // [X, Y, X, Y] Cutout/supress some sides. this may behave badly with compartments or mesh.
 supress_sides_radius=wall; // Add a rounding to the cutout.
-supress_sides_offset=0; // 0, wall, [X, Y, Z] adjsut the coutout in all directions. + to grow, - so shrink
+supress_sides_offset=0; // 0, wall, [X, Y, Z] adjust the coutout in all directions. + to grow, - to shrink
 supress_sides_fn=30;
 
 // Mesh Settings
 // To make rounded corners and no mesh use any `mesh_type` > 0 and set `strut_gap` to a high value.
 // 0: No mesh, solid wall.
 // 1: Single direction mesh.
-// 2: Two direction cross mesh and 90 degree angle to eachother.
-// 3: Two direction mesh but mirrored around 90 axsis instead or rotated 90 degrees.
+// 2: Two direction cross mesh at 90 degree angle to eachother.
+// 3: Two direction mesh but mirrored around 90 axis instead or rotated 90 degrees.
 // 4: Calculate angle across the diagonal of each opening. You will also want to change `strut_gap` to a large number and set `strut_count_min=1`.
 // 5: No mesh, empty wall.
-// 6: Honycomb. Also set `strut_width=wall/4` and `strut_gap=wall*2`. To big of a `strut_gap` may fail to print. Other shapes can be generated with `mesh_fn` and reducing `mesh_inset_padding` may help.
+// 6: Honycomb. Also set `strut_width=wall/4` and `strut_gap=wall*2`. Too big of a `strut_gap` may fail to print. Other shapes can be generated with `mesh_fn` and reducing `mesh_inset_padding` may help.
 mesh_type=0; // Mesh type, see above.
 mesh_rotation=0; // 0-90 degrees.
 mesh_alt_rotation=mesh_rotation; // Alternate rotation for top and bottom faces.
@@ -48,23 +48,23 @@ mesh_do_bottom=false; // Include mesh on bottom plate.
 mesh_do_top=true; // Include mesh on top piece.
 mesh_do_interior=false; // Include mesh on inner walls.
 mesh_inset_padding=wall; // Leave some solid material before building strut frame. Anything less then wall/2 will likely fall apart.
-mesh_fn=mesh_type == 6 ? 6 : 40; // Complexity of curves in mesh's, increese for smoother curves.
+mesh_fn=mesh_type == 6 ? 6 : 40; // Complexity of curves in meshes, increase for smoother curves.
 strut_width=wall*2; // Width of each strut, 0=hollow.
 strut_gap=wall; // Width of the air gap between each strut. 0=fine air gaps.
 strut_count_min=0; // Optinal minimum number of struts regardless of size calulations.
-alt_strut_width=strut_width; // Width of struts going the other directions.
+alt_strut_width=strut_width; // Width of struts going the other direction.
 alt_strut_gap=strut_gap; // Width of gap going the other direction.
-alt_strut_count_min=strut_count_min; // Optinal minimum number of struts regardless of size calulations.
+alt_strut_count_min=strut_count_min; // Optional minimum number of struts regardless of size calculations.
 mesh_overflow=0; // Extra rows to add to the mesh. For example in the Honeycomb partial hexegons will be created along the edges.
 
 // Lid Settings
 // 0: No Lid. top may be rounded and can cause other rendering changes.
 // 1: Lid that slides off in the x direction.
-// 2: Lid with a snapped in hinge that rotates open, will make box one wlal taller.
+// 2: Lid with a snapped in hinge that rotates open, will make box one wall taller.
 // 3: Lid that snaps down onto the box. Also need to change lid_height to around 1.5mm.
-// 4: Stackable version of cover 1 there boxes slide into one another. You will need one cover for the last box.
-// 5: Oversized lid sits on top and has sides that extend down. (Needs snapp support)
-// 6: Stacking boxes, will make box 1/2 wall taller.
+// 4: Stackable version of cover 1. The boxes slide into one another. You will need one cover for the last box.
+// 5: Oversized lid sits on top and has sides that extend down. (Needs snap support)
+// 6: Stacking boxes, will make box 1/2 walls taller.
 lid_type=1; // Lid type, see above.
 has_thumbhole=true; // Add gripping locations for easy opening.
 has_coinslot=false; // Add slot in the top for dropping in components.
@@ -73,7 +73,7 @@ coinslot_x=20;	// Size in X direction
 coinslot_y=2.5;	// Size in Y direction
 coinslot_corner_radius=0; // rounded coinslot corners if >0; best if less than half the shorter coinslot dimension
 z_tolerance=0;   // Z tolerance can be tweaked separately, to make the top of the sliding lid be flush with the top of the box itself.
-extra_bottom=.15; // Extra bottm wall height to fit type 4 slider.
+extra_bottom=.15; // Extra bottom wall height to fit type 4 slider.
 hinge_inset=.75; // Size of the hinge connection.
 snap_inset=.25; // Amount of overhang for snaps to snap into place.
 snap_tolerance=tolerance; // You may need to add tolerance around lid and snaps to let them move freely.
@@ -85,39 +85,39 @@ lid_alt_offset=false; // Move lid in X instead of Y for printing.
 //Internal Structure (You may need to turn off `mesh_do_sides` or `mesh_do_bottom` for good results.)
 // You can also use `make_wall()` to manually add your own walls.
 // 1: Rounded bottom frame.
-// 2: Hexegon bottom frame. (To make this shape perfect set `comp_size_deep` to the width between to edges of the tile and set `comp_size_x` or `comp_size_y` to this this: `comp_size_deep / sqrt(3)*2`.
+// 2: Hexegon bottom frame. (To make this shape perfect set `comp_size_deep` to the width between to edges of the tile and set `comp_size_x` or `comp_size_y` to this: `comp_size_deep / sqrt(3)*2`.
 // 3: Rough bottom for make bits sit unevenly. (Partial)
-// 4: Verical rounding on cordner. Set `internal_size_deep` to `comp_size_deep` and `internal_size_circle` to the shortest `comp_size` for a circle.
-// 5: Vertical hexegon. Results may varry.
+// 4: Verical rounding on corner. Set `internal_size_deep` to `comp_size_deep` and `internal_size_circle` to the shortest `comp_size` for a circle.
+// 5: Vertical hexagon. Results may varry.
 internal_type=0; // Internal structure, see above.
 internal_rotate=false; // On lid axis or rotate to opposite.
 internal_size_deep=comp_size_deep/2; // How far into the box to start the internal structure. Should be `comp_size_deep/2` for type 1-2, `wall` for 3, or comp_size_deep for type 4-5.
 internal_size_circle=internal_type==1 ? internal_size_deep : internal_size_deep * 2 / sqrt(3); // Use this calculation, or the shorter comp_size for type 4-5.
 internal_fn=internal_type==1 || internal_type==4 ? 60 : 6; // Complexity of internal curves, may need to increase for larger or smoother curves.
 internal_wall=wall; // Custom size for internal walls.
-internal_wall_deep=comp_size_deep; // If set to lower then comp_size_deep then the internal walls will be this tall.
+internal_wall_deep=comp_size_deep; // If set to lower than comp_size_deep then the internal walls will be this tall.
 
 // Text Settings
 // 0: None.
-// 1: Cutout. Remove material formt he wall.
-// 2: Raised. If a mesh is ued part of it is filled in to hold the text. Lids 0 and 3 are printed upside down by default. With this option used they will require supports regardless of the orrientation printed.
+// 1: Cutout. Remove material from the wall.
+// 2: Raised. If a mesh is used, part of it is filled in to hold the text. Lids 0 and 3 are printed upside down by default. With this option used they will require supports regardless of the orrientation printed.
 text_type=0; // Text type, see above.
-text_depth=wall/6; // Distance to cutout text or raise it. User `wall` to cut through.
+text_depth=wall/6; // Distance to cutout text or raise it. Use `wall` to cut through.
 text_size=5; // Font Size.
-text_font="Courier New:style=Bold"; // Use Hepl -> Font List to see options.
+text_font="Courier New:style=Bold"; // Use Help -> Font List to see options.
 text_message="Red Player"; // Message Text, or use `["Line 1", "Line 2"]` for multiline.
-text_message_compartments=false;//[["AA", "BB", "CC"], ["AB", "BC", "CD"]]; // Custom text for compartments in top or bottom. Also support multiline as `[[ ["A", "B"] ]]`.
+text_message_compartments=false;//[["AA", "BB", "CC"], ["AB", "BC", "CD"]]; // Custom text for compartments in top or bottom. Also supports multiline as `[[ ["A", "B"] ]]`.
 text_sides=true;//[true, true, true, false]; // Sides to put text on, [X, Y, X, Y]
 text_top=true; // Put Text on the top.
 text_bottom=false; // Put Text on the bottom.
 text_rotation=0; // Rotate the top and bottom text by X degrees. 90 will rotate from the X axis to the Y axis.
 text_offset=0; // Text is verticaly centered in the wall. This may look "off" due to casing or hanging tails. You can manually adjust the vertical alignment with this setting.
 text_fn=30; // Complexity of the letters, may need to increese with larger fonts.
-text_backdrop_scale=[.9, 1.5]; // Font size scaleing used on the backdrop when `text_type=2` is used on sides with a mesh.
+text_backdrop_scale=[.9, 1.5]; // Font size scaling used on the backdrop when `text_type=2` is used on sides with a mesh.
 
 // Complex Structure
 make_complex_box=false; // Use an array of objects from `complex_box` to create many smaller boxes within the larger box.
-internal_grow_down=true; // If set compartments will be extruded into the larger box from the top to make a flush surface. (May make a model that uses a lot of material.
+internal_grow_down=true; // If set compartments will be extruded into the larger box from the top to make a flush surface. (May result in a model that uses a lot of material).
 internal_empty_bottom=false; // If set the area blow each box will be empty. This will not be printable on a FDM printer unless supports are included internally but still may save material and print time.
 
 // Main Program
@@ -175,7 +175,7 @@ module make_complex_box() {
     }
 }
 
-/*** Code to create a custom wall withing a bigger box. ***/
+/*** Code to create a custom wall within a bigger box. ***/
 module make_wall(row, offset, rotate, internal_size_deep=internal_size_deep, internal_wall=internal_wall, wall=wall) {
     offset_row=calc_offset(row, rotate ? comp_size_x : comp_size_y, internal_wall=internal_wall, wall=wall);
     
@@ -191,13 +191,13 @@ module make_wall(row, offset, rotate, internal_size_deep=internal_size_deep, int
 /*** Code used in make_mesh to create complex struts that may be reused elsewhere. ***/
 module make_struts (x, y, thickness, number_of_struts, struts_width, angle, mesh_type=mesh_type) {
 	angle2 = angle % 180;
-	hypotenuse = sqrt(pow(x,2)+pow(y,2)); //lenght of the diagonal
+	hypotenuse = sqrt(pow(x,2)+pow(y,2)); //length of the diagonal
 	number_of_struts = mesh_type == 5 ? 0 : floor(number_of_struts);
     length = mesh_rotation/90*x+(1-mesh_rotation/90)*y;
     //length= angle%180 > 45 ? mesh_rotation/90*y+(1-mesh_rotation/90)*x : mesh_rotation/90*x+(1-mesh_rotation/90)*y;
     //
         if(number_of_struts > 0) {
-            // Repating Mesh
+            // Repaeting Mesh
             if(mesh_type == 6) {
                 difference(){
                     square([x, y]);
@@ -641,7 +641,7 @@ module make_box() {
     make_box_internal(comp_size_x=comp_size_x, comp_size_y=comp_size_y, internal_size_deep=internal_size_deep, internal_type=internal_type, repeat_x=repeat_x, repeat_y=repeat_y, internal_fn=internal_fn, internal_rotate=internal_rotate, wall=wall, internal_wall=internal_wall, internal_wall_deep=internal_wall_deep);
 }
 
-/*** Code to add text to a box wall.  ***/
+/*** Code to add text to a box wall. ***/
 module make_text(box_x, box_y, box_z, base_rotation, rotate_z) {
     if(text_type == 1 || text_type == 2) {
         rotate([rotate_z ? base_rotation : 0, 0, rotate_z ? text_rotation : base_rotation])


### PR DESCRIPTION
I've fixed some of the typos in the comments, did a quick brushup on the MarkDown syntax in the readme  and also fixed the indentations in `Ultimate_Box_Generator.scad`.

One of the typos was, that "suppress" was spelled as "supress".
I only fixed it in the comments though and didn´t  change it in variable names as this would introduce backwards compatiobility issues.